### PR TITLE
Profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ irb(main):006:0> User.count
    (32.0ms)  SELECT COUNT(*) FROM "users"
 => 34445
 ~~~
+
+Add some profiling


### PR DESCRIPTION
For profiling I used 3 gems: 
- [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler)
- [flamegraph](https://github.com/SamSaffron/flamegraph)
- [memory_profiler](https://github.com/SamSaffron/memory_profiler)


And we have code like:

~~~ ruby
# before:
@posts = Post.limit(100)
# after
@posts = Post.includes(:post).limit(100)
~~~

We can see that **first code**(before) generate N+1 query: 
![](http://dl4.joxi.net/drive/2017/02/01/0011/2687/744063/63/507e187fb9.jpg)
and detailed image:
![](http://dl3.joxi.net/drive/2017/02/01/0011/2687/744063/63/048b195755.jpg)

Also **flamegraph** can show the same behavior for this code but in another variant:
![](http://dl3.joxi.net/drive/2017/02/01/0011/2687/744063/63/5f4e14cdd3.jpg)

Memory profile can show how many memories use our code and where is allocated(result log is very vert long):
![](http://dl4.joxi.net/drive/2017/02/01/0011/2687/744063/63/4010aa0bc8.jpg)
We can see that ActiveRecord use a lot of memory. Okay, let's go! 

# Fix code
I add method `includes` for fix N+1 queries and what we can see now:
only **2** query instead of **67** (because includes without condition):
![](http://dl4.joxi.net/drive/2017/02/01/0011/2687/744063/63/8a6f43bfb1.jpg)
detail: 
![](http://dl4.joxi.net/drive/2017/02/01/0011/2687/744063/63/0725769e72.jpg)

Also, we can see a huge difference in flamegrapht: 
![](http://dl4.joxi.net/drive/2017/02/01/0011/2687/744063/63/5ff0e0d2c2.jpg)

And it's not the end! We have next profiler and it shows for us: 
![](http://dl4.joxi.net/drive/2017/02/01/0011/2687/744063/63/b89c4adc78.jpg)

This case uses only 407504 bytes (407,5 kb) for activerecord, previous was **1 957 991** bytes (1957,9 kb)
And difference will be `1957991 - 407504 = 1550487 bytes` (**!!!!**) 
For this small example with a small amount of data!