### PR TITLE
Add simple rack app with two envirovment

### DIFF
--- a/rack_app/config.ru
+++ b/rack_app/config.ru
@@ -1,0 +1,21 @@
+require 'faker'
+require 'figaro'
+require 'thin'
+require 'webrick'
+
+Figaro::Application.new(path: 'config/application.yml',
+                        environment: ENV['RACK_ENV']).load
+
+response = "<h3>ENV: #{ENV['RACK_ENV']}</h3>
+            <h3>LAUNCHED ON: #{ENV['server']}</h3>
+
+            <p>Faker response:<br/>
+              <b>#{Faker::Lorem.sentence}</b>
+            </p>"
+
+Rack::Server.start(
+  :app => lambda do |e|
+    [200, {'Content-Type' => 'text/html'}, [response]]
+  end,
+  :server => ENV['server']
+)

--- a/rack_app/config/application.yml
+++ b/rack_app/config/application.yml
@@ -1,0 +1,5 @@
+development:
+  server: webrick
+
+staging:
+  server: thin


### PR DESCRIPTION
For use app we should install gems:

1. `gem install thin`
2. `gem install figaro`
3. `gem install faker` 

# Staging

![](http://dl3.joxi.net/drive/2017/02/14/0011/2687/744063/63/b10bdd8dde.jpg)

We can run it: 

~~~ ruby
➜  rack_app git:(rack_app)  RACK_ENV=staging rackup config.ru
Thin web server (v1.7.0 codename Dunder Mifflin)
Maximum connections set to 1024
Listening on 0.0.0.0:8080, CTRL+C to stop
~~~

Development is default env or we can pass it: 
![](http://dl3.joxi.net/drive/2017/02/14/0011/2687/744063/63/8cf4aa231d.jpg)

~~~ ruby
➜  rack_app git:(rack_app)  RACK_ENV=development rackup config.ru
[2017-02-14 19:04:32] INFO  WEBrick 1.3.1
[2017-02-14 19:04:32] INFO  ruby 2.3.1 (2016-04-26) [x86_64-darwin16]
[2017-02-14 19:04:32] INFO  WEBrick::HTTPServer#start: pid=16171 port=8080
::1 - - [14/Feb/2017:19:04:38 EET] "GET / HTTP/1.1" 200 191
- -> /
::1 - - [14/Feb/2017:19:04:39 EET] "GET /favicon.ico HTTP/1.1" 200 191
http://localhost:8080/ -> /favicon.ico
~~~ 